### PR TITLE
changes to make the package run with the example code

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.3-
+ConjugatePriors 0.1.2-
 Distributions 0.6-
 PDMats 0.3.1-
 Devectorize 0.4.0-

--- a/demo.jl
+++ b/demo.jl
@@ -1,8 +1,7 @@
-require("src/DirichletProcessMixtures.jl")
-
 using DirichletProcessMixtures
 using Distributions
-    
+using ConjugatePriors: NormalWishart
+
 function ball(N::Int64, x::Float64, y::Float64)
     return randn(2, N) .+ [x, y]
 end
@@ -40,15 +39,17 @@ end
 
 niter = infer(gm, maxiter, 1e-5; iter_callback=iter_callback)
 
+Pkg.add("PyCall")
+
 using PyCall
 @pyimport pylab
 
 #convergence plot
 #pylab.plot([1:niter], lb_log[1:niter]; color=[1., 0., 0.])
-pylab.plot([1:niter], tl_log[1:niter]; color=[0., 0., 1.])
+pylab.plot(1:niter, tl_log[collect(1:niter)]; color=[0., 0., 1.])
 
 pylab.show()
-    
+
 z = map_assignments(gm)
 for k=1:T
 xk = x[:, z .== k]

--- a/src/DirichletProcessMixtures.jl
+++ b/src/DirichletProcessMixtures.jl
@@ -1,6 +1,6 @@
 module DirichletProcessMixtures
 
-using NumericExtensions
+using ConjugatePriors
 using Devectorize
 using ArrayViews
 using Distributions
@@ -10,4 +10,12 @@ include("TSBPMM.jl")
 include("student.jl")
 include("gaussian_mixture.jl")
 
+# Multidimensional gamma / partial gamma function
+function lpgamma(p::Int, a::Float64)
+    res::Float64 = p * (p - 1.0) / 4.0 * log(pi)
+    for ii in 1:p
+        res += Distributions.lgamma(a + (1.0 - ii) / 2.0)
+    end
+    return res
+end
 end

--- a/src/TSBPMM.jl
+++ b/src/TSBPMM.jl
@@ -134,7 +134,7 @@ function logpi!(π::Vector{Float64}, mix::TSBPMM)
     end
     π[T(mix)] = r
 end
-using Debug
+
 function loglikelihood(mix::TSBPMM)
     ll = 0.
 
@@ -192,4 +192,3 @@ function pi!(π::Vector{Float64}, mix::TSBPMM)
 end
 
 export TSBPMM, infer, variational_lower_bound, map_assignments, pi!, T
-

--- a/src/gaussian_mixture.jl
+++ b/src/gaussian_mixture.jl
@@ -1,4 +1,4 @@
-import Distributions.MvNormalStats, Distributions.lpgamma, Distributions.suffstats, Distributions.mean
+import Distributions.MvNormalStats, Distributions.suffstats, Distributions.mean
 import ConjugatePriors.NormalWishart
 function suffstats(D::Type{MvNormal}, x::Matrix{Float64}, w::DenseArray{Float64})
     d = size(x, 1)

--- a/src/student.jl
+++ b/src/student.jl
@@ -1,5 +1,4 @@
 import PDMats.dim
-
 immutable MultivariateStudent
     nu::Float64
     mu::Vector{Float64}
@@ -8,7 +7,7 @@ end
 
 function MultivariateStudent(nu::Float64, mu::Vector{Float64}, sigma::Matrix{Float64})
     return MultivariateStudent(nu, mu, PDMat(sigma))
-end 
+end
 
 dim(t::MultivariateStudent) = dim(t.sigma)
 
@@ -24,7 +23,8 @@ function pdf(t::MultivariateStudent, x::Vector{Float64})
     return exp(logpdf(t, x))
 end
 
-function predictive(nw::NormalWishart)
+
+function predictive(nw::ConjugatePriors.NormalWishart)
     nu = nw.nu - nw.dim + 1
     return MultivariateStudent(nu, nw.mu, inv(nw.Tchol) * (nw.kappa + 1)/(nw.kappa * nu))
 end


### PR DESCRIPTION
I made some tweaks to make the package work. Mainly, I removed the dependence on NumericExtensions which does not work anymore. I also fixed the bugs related to NormalWishardt being migrated to ConjugatePriors package.
